### PR TITLE
Fix orders API

### DIFF
--- a/app/Orders/controller.js
+++ b/app/Orders/controller.js
@@ -2,10 +2,11 @@ const Order = require('./model');
 
 const createOrder = function (req, res, next) {
   const {
-    userId,
     items,
     totalCost
   } = req.body;
+  
+  const userId = req.user._id;
 
   const order = new Order({
     userId,


### PR DESCRIPTION
The orders API is broken because the `userId` props is not present in `req.body` but in `req.user`. 

working example: https://github.com/Codebrahma/Restaurant-Express-API/blob/7ebc02c0f389cc9158cc17ab3f5adf36855942ed/app/utils/roleAuthorization.js#L6